### PR TITLE
distributed: `type(x) == types.FooType` -> `inspect.isfoo(x)`

### DIFF
--- a/direct/src/distributed/ConnectionRepository.py
+++ b/direct/src/distributed/ConnectionRepository.py
@@ -7,7 +7,7 @@ from direct.distributed.DoCollectionManager import DoCollectionManager
 from direct.showbase import GarbageReport
 from .PyDatagramIterator import PyDatagramIterator
 
-import types
+import inspect
 import gc
 
 __all__ = ["ConnectionRepository", "GCTrigger"]
@@ -327,13 +327,13 @@ class ConnectionRepository(
             if classDef is None:
                 self.notify.debug("No class definition for %s." % (className))
             else:
-                if type(classDef) == types.ModuleType:
+                if inspect.ismodule(classDef):
                     if not hasattr(classDef, className):
                         self.notify.warning("Module %s does not define class %s." % (className, className))
                         continue
                     classDef = getattr(classDef, className)
 
-                if type(classDef) != types.ClassType and type(classDef) != types.TypeType:
+                if inspect.isclass(classDef):
                     self.notify.error("Symbol %s is not a class name." % (className))
                 else:
                     dclass.setClassDef(classDef)
@@ -388,7 +388,7 @@ class ConnectionRepository(
                     if classDef is None:
                         self.notify.error("No class definition for %s." % className)
                     else:
-                        if type(classDef) == types.ModuleType:
+                        if inspect.ismodule(classDef):
                             if not hasattr(classDef, className):
                                 self.notify.error("Module %s does not define class %s." % (className, className))
                             classDef = getattr(classDef, className)

--- a/direct/src/distributed/ServerRepository.py
+++ b/direct/src/distributed/ServerRepository.py
@@ -7,6 +7,8 @@ from direct.task import Task
 from direct.directnotify import DirectNotifyGlobal
 from direct.distributed.PyDatagram import PyDatagram
 
+import inspect
+
 
 class ServerRepository:
 
@@ -273,12 +275,12 @@ class ServerRepository:
             if classDef == None:
                 self.notify.debug("No class definition for %s." % (className))
             else:
-                if type(classDef) == types.ModuleType:
+                if inspect.ismodule(classDef):
                     if not hasattr(classDef, className):
                         self.notify.error("Module %s does not define class %s." % (className, className))
                     classDef = getattr(classDef, className)
 
-                if type(classDef) != types.ClassType and type(classDef) != types.TypeType:
+                if inspect.isclass(classDef):
                     self.notify.error("Symbol %s is not a class name." % (className))
                 else:
                     dclass.setClassDef(classDef)


### PR DESCRIPTION
This is more compatible across Python 2 vs. 3.

[skip ci]